### PR TITLE
Allow adding directories with precedence to the search path.

### DIFF
--- a/include/tinygettext/dictionary_manager.hpp
+++ b/include/tinygettext/dictionary_manager.hpp
@@ -22,11 +22,11 @@
 
 #include "tinygettext_Export.h"
 
+#include <dequeue>
 #include <memory>
 #include <set>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 #include "dictionary.hpp"
 #include "language.hpp"
@@ -44,7 +44,7 @@ private:
   typedef std::unordered_map<Language, Dictionary*, Language_hash> Dictionaries;
   Dictionaries dictionaries;
 
-  typedef std::vector<std::string> SearchPath;
+  typedef std::dequeue<std::string> SearchPath;
   SearchPath search_path;
 
   std::string charset;
@@ -83,8 +83,9 @@ public:
   void set_charset(const std::string& charset);
 
   /** Add a directory to the search path for dictionaries, earlier
-      added directories have higher priority then later added ones */
-  void add_directory(const std::string& pathname);
+      added directories have higher priority then later added ones.
+      Set @p precedence to true to invert this for a single addition. */
+  void add_directory(const std::string& pathname, bool precedence = false);
 
   /** Remove a directory from the search path */
   void remove_directory(const std::string& pathname);

--- a/src/dictionary_manager.cpp
+++ b/src/dictionary_manager.cpp
@@ -233,11 +233,14 @@ DictionaryManager::get_use_fuzzy() const
 }
 
 void
-DictionaryManager::add_directory(const std::string& pathname)
+DictionaryManager::add_directory(const std::string& pathname, bool precedence /* = false */)
 {
     if(std::find(search_path.begin(), search_path.end(), pathname) == search_path.end()) {
         clear_cache(); // adding directories invalidates cache
-        search_path.push_back(pathname);
+        if(precedence)
+            search_path.push_front(pathname)
+        else
+            search_path.push_back(pathname);
     }
 }
 


### PR DESCRIPTION
This way clients have more control over the search path without
having to clear the whole path upon later additions.

Alternate way of doing #4.
